### PR TITLE
fix(junit): Remove `junit-platform-suite-commons` dependency in junit-6.yml

### DIFF
--- a/rewrite-test/src/main/resources/META-INF/rewrite/junit/junit6/junit-6.yml
+++ b/rewrite-test/src/main/resources/META-INF/rewrite/junit/junit6/junit-6.yml
@@ -21,7 +21,7 @@ recipeList:
       artifactId: junit-platform-runner
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.junit.platform
-      artifactId: junit-platform-suite-common
+      artifactId: junit-platform-suite-commons
 
   # Dependency Versions
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:


### PR DESCRIPTION
## Description

As seen on https://central.sonatype.com/artifact/org.junit.platform/junit-platform-suite-commons/versions

## Checklist

- [x] I have reviewed and followed the [contributing guidelines](https://github.com/arconia-io/arconia-migrations/blob/main/CONTRIBUTING.md).
- [ ] I have run a local build and made sure all tests pass (`./gradlew build`).
- [ ] I have signed off the [Developer Certificate of Origin (DCO)](https://github.com/arconia-io/arconia-migrations/blob/main/dco.txt).
- [x] I assert that I have read the [Arconia Code of Conduct](https://github.com/arconia-io/arconia-migrations/blob/main/CODE_OF_CONDUCT.md) and agree to abide by it.
